### PR TITLE
CTH-206 add schema.core/defn to public api

### DIFF
--- a/src/puppetlabs/cthun/message.clj
+++ b/src/puppetlabs/cthun/message.clj
@@ -94,10 +94,10 @@
       (dissoc :_data_flags)
       (dissoc :_hops)))
 
-(defn add-hop
+(s/defn ^:always-validate add-hop :- Message
   "Returns the message with a hop for the specified 'stage' added."
-  ([message stage] (add-hop message stage (ks/timestamp)))
-  ([message stage timestamp]
+  ([message :- Message stage :- s/Str] (add-hop message stage (ks/timestamp)))
+  ([message :- Message stage :- s/Str timestamp :- ISO8601]
    ;; TODO(richardc) this server field should come from the cert of this instance
      (let [hop {:server "cth://fake/server"
                 :time   timestamp

--- a/test/puppetlabs/cthun/message_test.clj
+++ b/test/puppetlabs/cthun/message_test.clj
@@ -18,23 +18,23 @@
             :_destination ""}))))
 
 (deftest add-hop-test
-  (with-redefs [puppetlabs.kitchensink.core/timestamp (fn [] "Tomorrow")]
+  (with-redefs [puppetlabs.kitchensink.core/timestamp (fn [] "1971-02-03T04:05:06.000Z")]
     (testing "it adds a hop"
       (is (= [{:server "cth://fake/server"
-                       :time   "Another day"
+                       :time   "1971-09-01T03:04:05.000Z"
                        :stage  "potato"}]
-             (:_hops (add-hop (make-message) "potato" "Another day")))))
+             (:_hops (add-hop (make-message) "potato" "1971-09-01T03:04:05.000Z")))))
     (testing "it allows timestamp to be optional"
       (is (= [{:server "cth://fake/server"
-               :time   "Tomorrow"
+               :time   "1971-02-03T04:05:06.000Z"
                :stage  "potato"}]
              (:_hops (add-hop (make-message) "potato")))))
     (testing "it adds hops in the expected order"
       (is (= [{:server "cth://fake/server"
-               :time   "Tomorrow"
+               :time   "1971-02-03T04:05:06.000Z"
                :stage  "potato"}
               {:server "cth://fake/server"
-               :time   "Tomorrow"
+               :time   "1971-02-03T04:05:06.000Z"
                :stage  "mash"}]
              (:_hops (-> (make-message)
                          (add-hop "potato")


### PR DESCRIPTION
With this set of commits we ensure things we consider part of the public API are declared with `schema.core/defn`, add missing tests, and fix existing ones.
