### PR TITLE
CTH-208 renamings

### DIFF
--- a/src/puppetlabs/cthun/message.clj
+++ b/src/puppetlabs/cthun/message.clj
@@ -32,7 +32,7 @@
   {:id           MessageId
    :sender       Uri
    :targets      [Uri]
-   :data_schema  s/Str
+   :message_type s/Str
    :expires      ISO8601
    (s/optional-key :destination_report) s/Bool})
 
@@ -76,7 +76,7 @@
   []
   {:id ""
    :targets []
-   :data_schema ""
+   :message_type ""
    :sender ""
    :expires "1970-01-01T00:00:00.000Z"
    :_hops []

--- a/test/puppetlabs/cthun/message_test.clj
+++ b/test/puppetlabs/cthun/message_test.clj
@@ -21,7 +21,7 @@
             :sender ""
             :targets []
             :expires "1970-01-01T00:00:00.000Z"
-            :data_schema ""
+            :message_type ""
             :_hops []
             :_data_frame []
             :_data_flags #{}


### PR DESCRIPTION
As part of the CTH-208 specification review, we are changing some of the names of envelope fields, and their semantics.  This updates the common message class to use it.
