### PR TITLE
CTH-329 Accept additional arguments to make-message

### DIFF
--- a/src/puppetlabs/cthun/message.clj
+++ b/src/puppetlabs/cthun/message.clj
@@ -145,13 +145,14 @@
 
 (s/defn ^:always-validate make-message :- Message
   "Returns a new empty message structure"
-  []
-  (let [message {:id (ks/uuid)
-                 :targets []
-                 :message_type ""
-                 :sender ""
-                 :expires "1970-01-01T00:00:00.000Z"
-                 :_chunks {}}]
+  [& args]
+  (let [message (into {:id (ks/uuid)
+                       :targets []
+                       :message_type ""
+                       :sender ""
+                       :expires "1970-01-01T00:00:00.000Z"
+                       :_chunks {}}
+                      (apply hash-map args))]
     (set-data message (byte-array 0))))
 
 ;; message encoding/codecs

--- a/test/puppetlabs/cthun/message_test.clj
+++ b/test/puppetlabs/cthun/message_test.clj
@@ -25,7 +25,15 @@
             :targets []
             :expires "1970-01-01T00:00:00.000Z"
             :message_type ""}
-           (dissoc (make-message) :_chunks :id)))))
+           (dissoc (make-message) :_chunks :id))))
+  (testing "it makes a message with parameters"
+    (let [message (make-message :sender "cth://client01.example.com/test"
+                                :targets ["cth:///server"])]
+      (is (= {:sender "cth://client01.example.com/test"
+              :targets ["cth:///server"]
+              :expires "1970-01-01T00:00:00.000Z"
+              :message_type ""}
+           (dissoc message :_chunks :id))))))
 
 (deftest set-expiry-test
   (testing "it sets expiries to what you tell it"


### PR DESCRIPTION
Here we take any additional arguments to make-message and mix them into the
defaults.

Allows this:

```
(let [message (-> (make-message)
                  (assoc :sender "cth://someone/somewhere"))])
```

To become this:

```
(let [message (make-message :sender "cth://someone/somewhere")])
```
