### PR TITLE
(maint) Add an optional in-reply-to to the Envelope

### DIFF
--- a/src/puppetlabs/cthun/protocol.clj
+++ b/src/puppetlabs/cthun/protocol.clj
@@ -22,6 +22,7 @@
 (def Envelope
   "Defines the envelope format of a v2 message"
   {:id           MessageId
+   (s/optional-key :in-reply-to) MessageId
    :sender       Uri
    :targets      [Uri]
    :message_type s/Str


### PR DESCRIPTION
This is a proposed change to the protocol - when responding to a request you
want a place to say what request you are responding to.  This is common enough
to hoist into the Envelope
