### PR TITLE
CTH-313 rename to pcp-common

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+# 0.4.0
+
+* Renamed from former codenames to new component names.
+
 # 0.2.0
 
 * Removed server state from Message (CTH-328)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# clj-cthun-message
+# clj-pcp-common
 
-CThun message codec
+PCP message codec and protocol helpers
 
-https://github.com/puppetlabs/cthun-specifications
+https://github.com/puppetlabs/pcp-specifications
 
 
 # Installation
@@ -10,7 +10,7 @@ https://github.com/puppetlabs/cthun-specifications
 The jar is distributed via the internal nexus server, to use it add
 the following to your project.clj
 
-    :dependencies [[puppetlabs/cthun-message "0.1.0"]]
+    :dependencies [[puppetlabs/pcp-common "0.4.0"]]
 
     :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
                    ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
@@ -19,7 +19,7 @@ the following to your project.clj
 
 ``` clojure
 (ns example
-   (:require [puppetlabs.cthun.message :as message]))
+   (:require [puppetlabs.pcp.message :as message]))
 
 (def message (message/make-message))
 ```

--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,9 @@
    :password :env/nexus_jenkins_password
    :sign-releases false})
 
-(defproject puppetlabs/cthun-message "0.3.2-SNAPSHOT"
-  :description "Message serialisation codec for cthun"
-  :url "https://github.com/puppetlabs/clj-cthun-message"
+(defproject puppetlabs/pcp-common "0.4.0-SNAPSHOT"
+  :description "Common protocol components for PCP"
+  :url "https://github.com/puppetlabs/clj-pcp-common"
   :license {:name ""
             :url ""}
 

--- a/src/puppetlabs/pcp/message.clj
+++ b/src/puppetlabs/pcp/message.clj
@@ -1,10 +1,10 @@
-(ns puppetlabs.cthun.message
+(ns puppetlabs.pcp.message
   (:require [org.clojars.smee.binary.core :as b]
             [cheshire.core :as cheshire]
             [clj-time.core :as t]
             [clj-time.format :as tf]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.cthun.protocol :refer [Envelope ISO8601]]
+            [puppetlabs.pcp.protocol :refer [Envelope ISO8601]]
             [schema.core :as s]
             [slingshot.slingshot :refer [try+ throw+]]))
 

--- a/src/puppetlabs/pcp/protocol.clj
+++ b/src/puppetlabs/pcp/protocol.clj
@@ -1,4 +1,4 @@
-(ns puppetlabs.cthun.protocol
+(ns puppetlabs.pcp.protocol
   (:require [clojure.string :as str]
             [puppetlabs.kitchensink.core :as ks]
             [schema.core :as s]))

--- a/test/puppetlabs/pcp/message_test.clj
+++ b/test/puppetlabs/pcp/message_test.clj
@@ -1,6 +1,6 @@
-(ns puppetlabs.cthun.message-test
+(ns puppetlabs.pcp.message-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.cthun.message :refer :all]
+            [puppetlabs.pcp.message :refer :all]
             [puppetlabs.kitchensink.core :as ks]
             [schema.core :as s]
             [slingshot.test]))
@@ -102,22 +102,22 @@
 (deftest decode-test
   (with-redefs [schema.core/validate (fn [s d] d)]
     (testing "it only handles version 1 messages"
-      (is (thrown+? [:type :puppetlabs.cthun.message/message-malformed]
+      (is (thrown+? [:type :puppetlabs.pcp.message/message-malformed]
                     (decode (byte-array [2])))))
     (testing "it insists on envelope chunk first"
-      (is (thrown+? [:type :puppetlabs.cthun.message/message-invalid]
+      (is (thrown+? [:type :puppetlabs.pcp.message/message-invalid]
                     (decode (byte-array [1,
                                          2, 0 0 0 2, 123 125])))))
     (testing "it decodes the null message"
       (is (= (dissoc (message->envelope (make-message)) :id)
              (dissoc (message->envelope (decode (byte-array [1, 1, 0 0 0 2, 123 125]))) :id))))
     (testing "it insists on a well-formed envelope"
-      (is (thrown+? [:type :puppetlabs.cthun.message/envelope-malformed]
+      (is (thrown+? [:type :puppetlabs.pcp.message/envelope-malformed]
                     (decode (byte-array [1,
                                          1, 0 0 0 1, 123])))))
     (testing "it insists on a complete envelope"
       (with-redefs [schema.core/validate (fn [s d] (throw (Exception. "oh dear")))]
-        (is (thrown+? [:type :puppetlabs.cthun.message/envelope-invalid]
+        (is (thrown+? [:type :puppetlabs.pcp.message/envelope-invalid]
                       (decode (byte-array [1,
                                            1, 0 0 0 2, 123 125]))))))
     (testing "data is accessible"

--- a/test/puppetlabs/pcp/protocol_test.clj
+++ b/test/puppetlabs/pcp/protocol_test.clj
@@ -1,6 +1,6 @@
-(ns puppetlabs.cthun.protocol-test
+(ns puppetlabs.pcp.protocol-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.cthun.protocol :refer :all]
+            [puppetlabs.pcp.protocol :refer :all]
             [puppetlabs.kitchensink.core :as ks]
             [schema.core :as s]))
 


### PR DESCRIPTION
Here we rename away from the codename and to the project name.

Namespaces puppetlabs.cthun -> puppetlabs.pcp
Repository clj-cthun-message -> clj-pcp-common
Release name puppetlabs/cthun-message -> puppetlabs/pcp-common
