### PR TITLE
(maint) prepare to be an open project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,29 @@
-# 0.4.0
+## 0.4.1
+
+This is a maintenance release
+
+* [CTH-311](https://tickets.puppetlabs.com/browse/CTH-311) Updated
+  Uri scheme from `cth` to `pcp`
+
+## 0.4.0
 
 * Renamed from former codenames to new component names.
 
-# 0.2.0
+## 0.2.0
 
 * Removed server state from Message (CTH-328)
 * Removed add-hops function
 * Added add-debug add-json-debug functions
 * Now verify that MessageId looks like a uuid
 
-# 0.1.0
+## 0.1.0
 
 * Added prismatic schema schema.core/defn decorations to the rest of
   the public api functions (CTH-206)
 * Renamed Endpoint -> Uri, and reworked envelope schema for changes to
   cthun specifications (CTH-210)
 
-# 0.0.1
+## 0.0.1
 
 * Initial internal release, extracted from cthun server (CTH-185)
 * Added set-expiry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# How to contribute
+
+Third-party patches are essential for keeping puppet open-source projects
+great. We want to keep it as easy as possible to contribute changes that
+allow you to get the most out of our projects. There are a few guidelines
+that we need contributors to follow so that we can have a chance of keeping on
+top of things.  For more info, see our canonical guide to contributing:
+
+[https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -100,3 +100,9 @@ Returns the network representation of the message
 ```
 
 Returns a message decoded from its network representation
+
+# Support
+
+We use the [Puppet Communications Protocol project on
+JIRA](https://tickets.puppetlabs.com/browse/PCP)
+with the component `clj-pcp-common` for tickets on `puppetlabs/pcp-common`.


### PR DESCRIPTION
Here we add a CONTRIBUTING.md, a forward reference to our issue tracker to the
README.md, and make the CHANGELOG.md follow the same format as that established
by trapperkeeper-webserver-jetty9 in preparation of being an official
PuppetLabs open library.