### PR TITLE
(PCP-42) Add version_error message schema

### DIFF
--- a/src/puppetlabs/pcp/protocol.clj
+++ b/src/puppetlabs/pcp/protocol.clj
@@ -57,6 +57,12 @@
   "Data schema for http://puppetlabs.com/ttl_expired"
   {:id MessageId})
 
+(def VersionErrorMessage
+  "Data schema for http://puppetlabs.com/version_error"
+  {:id MessageId
+   :target s/Str
+   :reason s/Str})
+
 (def DebugChunk
   "Data schema for a debug chunk"
   {:hops [{(s/required-key :server) Uri


### PR DESCRIPTION
Here we add the version_error message schema as described in the
pcp-specifications.