### PR TITLE
(PCP-467) Disable schema validations by default

### DIFF
--- a/dev-resources/Makefile.i18n
+++ b/dev-resources/Makefile.i18n
@@ -19,6 +19,11 @@ LOCALES=$(basename $(notdir $(wildcard locales/*.po)))
 BUNDLE_DIR=$(subst .,/,$(BUNDLE))
 BUNDLE_FILES=$(patsubst %,resources/$(BUNDLE_DIR)/Messages_%.class,$(MESSAGE_LOCALE) $(LOCALES))
 FIND_SOURCES=find src -name \*.clj
+# xgettext before 0.19 does not understand --add-location=file. Even CentOS
+# 7 ships with an older gettext. We will therefore generate full location
+# info on those systems, and only file names where xgettext supports it
+LOC_OPT=$(shell xgettext --add-location=file -f - </dev/null >/dev/null 2>&1 && echo --add-location=file || echo --add-location)
+
 LOCALES_CLJ=resources/locales.clj
 define LOCALES_CLJ_CONTENTS
 {
@@ -36,24 +41,29 @@ i18n: update-pot msgfmt
 update-pot: locales/messages.pot
 
 locales/messages.pot: $(shell $(FIND_SOURCES)) | locales
-	@tmp=$(mktemp $@.tmp.XXXX);                                        \
-	$(FIND_SOURCES)                                                    \
-	    | xgettext --from-code=UTF-8 --language=lisp                   \
-	               --copyright-holder 'Puppet <docs@puppet.com>' -F    \
-	               --package-name "$(BUNDLE)"                          \
-	               --package-version "$(BUNDLE_VERSION)"               \
-	               --msgid-bugs-address "docs@puppet.com"              \
-	               -ktrs:1 -ki18n/trs:1                                \
-	               -ktru:1 -ki18n/tru:1                                \
-	               -ktrun:1,2 -ki18n/trun:1,2                          \
-	               -ktrsn:1,2 -ki18n/trsn:1,2                          \
-	               --add-comments -o $tmp -f -;                        \
-	sed -i -e 's/charset=CHARSET/charset=UTF-8/' $tmp;                 \
-	sed -i -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $tmp; \
-	if ! diff -q -I POT-Creation-Date $tmp $@ >& /dev/null; then       \
-	    mv $tmp $@;                                                    \
-	else                                                               \
-	    rm $tmp;                                                       \
+	@tmp=$$(mktemp $@.tmp.XXXX);                                            \
+	$(FIND_SOURCES)                                                         \
+	    | xgettext --from-code=UTF-8 --language=lisp                        \
+	               --copyright-holder='Puppet <docs@puppet.com>'            \
+	               --package-name="$(BUNDLE)"                               \
+	               --package-version="$(BUNDLE_VERSION)"                    \
+	               --msgid-bugs-address="docs@puppet.com"                   \
+	               -k                                                       \
+	               -kmark:1 -ki18n/mark:1                                   \
+	               -ktrs:1 -ki18n/trs:1                                     \
+	               -ktru:1 -ki18n/tru:1                                     \
+	               -ktrun:1,2 -ki18n/trun:1,2                               \
+	               -ktrsn:1,2 -ki18n/trsn:1,2                               \
+	               $(LOC_OPT)                                               \
+	               --add-comments --sort-by-file                            \
+	               -o $$tmp -f -;                                           \
+	sed -i.bak -e 's/charset=CHARSET/charset=UTF-8/' $$tmp;                 \
+	sed -i.bak -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $$tmp; \
+	rm -f $$tmp.bak;                                                        \
+	if ! diff -q -I POT-Creation-Date $$tmp $@ >/dev/null 2>&1; then        \
+	    mv $$tmp $@;                                                        \
+	else                                                                    \
+	    rm $$tmp; touch $@;                                                 \
 	fi
 
 # Run msgfmt over all .po files to generate Java resource bundles

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -17,6 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/puppetlabs/pcp/message.clj:190
+#: src/puppetlabs/pcp/message.clj
 msgid "first chunk should be type 1"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,5 @@
+(def i18n-version "0.4.1")
+
 (defproject puppetlabs/pcp-common "0.5.1-SNAPSHOT"
   :description "Common protocol components for PCP"
   :url "https://github.com/puppetlabs/clj-pcp-common"
@@ -26,10 +28,10 @@
                  ;; try+/throw+
                  [slingshot "0.12.2"]
 
-                 [puppetlabs/i18n "0.3.0"]]
+                 [puppetlabs/i18n ~i18n-version]]
 
   :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]
-            [puppetlabs/i18n "0.3.0"]]
+            [puppetlabs/i18n ~i18n-version]]
 
   :profiles {:cljfmt {:plugins [[lein-cljfmt "0.3.0"]
                                 [lein-parent "0.2.1"]]

--- a/src/puppetlabs/pcp/message.clj
+++ b/src/puppetlabs/pcp/message.clj
@@ -198,7 +198,7 @@
           data-frame (or (:data data-chunk) (byte-array 0))
           data-flags (or (get-in data-chunk [:descriptor :flags]) #{})]
       (try+ (s/validate Envelope envelope)
-            (catch Throwable _
+            (catch Object _
               (throw+ {:type ::envelope-invalid
                        :message (:message &throw-context)})))
       (let [message (set-data (merge (make-message) envelope) data-frame data-flags)]

--- a/src/puppetlabs/pcp/message.clj
+++ b/src/puppetlabs/pcp/message.clj
@@ -51,7 +51,7 @@
   {:deprecated "0.2.0"}
   [message] (message->envelope message))
 
-(s/defn ^:always-validate set-expiry :- Message
+(s/defn set-expiry :- Message
   "Returns a message with new expiry"
   ([message :- Message number :- s/Int unit :- s/Keyword]
    (let [expiry (condp = unit
@@ -63,17 +63,17 @@
   ([message :- Message timestamp :- ISO8601]
    (assoc message :expires timestamp)))
 
-(s/defn ^:always-validate get-data :- ByteArray
+(s/defn get-data :- ByteArray
   "Returns the data from the data frame"
   [message :- Message]
   (get-in message [:_chunks :data :data] (byte-array 0)))
 
-(s/defn ^:always-validate get-debug :- ByteArray
+(s/defn get-debug :- ByteArray
   "Returns the data from the debug frame"
   [message :- Message]
   (get-in message [:_chunks :debug :data] (byte-array 0)))
 
-(s/defn ^:always-validate set-data :- Message
+(s/defn set-data :- Message
   "Sets the data for the data frame"
   ([message :- Message data :- ByteArray] (set-data message data #{}))
   ([message :- Message data :- ByteArray flags :- FlagSet]
@@ -81,7 +81,7 @@
                                                     :flags flags}
                                        :data data})))
 
-(s/defn ^:always-validate set-debug :- Message
+(s/defn set-debug :- Message
   "Sets the data for the debug frame"
   ([message :- Message data :- ByteArray] (set-debug message data #{}))
   ([message :- Message data :- ByteArray flags :- FlagSet]
@@ -89,31 +89,31 @@
                                                      :flags flags}
                                         :data data})))
 
-(s/defn ^:always-validate get-json-data :- s/Any
+(s/defn get-json-data :- s/Any
   "Returns the data from the data frame decoded from json"
   [message :- Message]
   (let [data (get-data message)
         decoded (cheshire/parse-string (bytes->string data) true)]
     decoded))
 
-(s/defn ^:always-validate get-json-debug :- s/Any
+(s/defn get-json-debug :- s/Any
   "Returns the data from the debug frame decoded from json"
   [message :- Message]
   (let [data (get-debug message)
         decoded (cheshire/parse-string (bytes->string data) true)]
     decoded))
 
-(s/defn ^:always-validate set-json-data :- Message
+(s/defn set-json-data :- Message
   "Sets the data to be the json byte-array version of data"
   [message :- Message data :- s/Any]
   (set-data message (string->bytes (cheshire/generate-string data))))
 
-(s/defn ^:always-validate set-json-debug :- Message
+(s/defn set-json-debug :- Message
   "Sets the debug data to be the json byte-array version of data"
   [message :- Message data :- s/Any]
   (set-debug message (string->bytes (cheshire/generate-string data))))
 
-(s/defn ^:always-validate make-message :- Message
+(s/defn make-message :- Message
   "Returns a new empty message structure"
   [& args]
   (let [message (into {:id (ks/uuid)
@@ -176,7 +176,7 @@
     (b/encode message-codec stream {:chunks chunks})
     (.toByteArray stream)))
 
-(s/defn ^:always-validate decode :- Message
+(s/defn decode :- Message
   "Returns a message object from a network format message"
   [bytes :- ByteArray]
   (let [stream (java.io.ByteArrayInputStream. bytes)

--- a/src/puppetlabs/pcp/protocol.clj
+++ b/src/puppetlabs/pcp/protocol.clj
@@ -69,12 +69,12 @@
            (s/optional-key :stage) s/Str
            (s/required-key :time) ISO8601}]})
 
-(s/defn ^:always-validate explode-uri :- [s/Str]
+(s/defn explode-uri :- [s/Str]
   "Parse an Uri string into its component parts.  Raises if incomplete"
   [uri :- Uri]
   (str/split (subs uri 6) #"/"))
 
-(s/defn ^:always-validate uri-wildcard? :- s/Bool
+(s/defn uri-wildcard? :- s/Bool
   [uri :- Uri]
   (let [chunks (explode-uri uri)]
     (some? (some (partial = "*") chunks))))

--- a/test/puppetlabs/pcp/message_test.clj
+++ b/test/puppetlabs/pcp/message_test.clj
@@ -1,9 +1,11 @@
 (ns puppetlabs.pcp.message-test
   (:require [clojure.test :refer :all]
             [puppetlabs.pcp.message :refer :all]
-            [puppetlabs.kitchensink.core :as ks]
+            [slingshot.test]
             [schema.core :as s]
-            [slingshot.test]))
+            [schema.test :as st]))
+
+(use-fixtures :once st/validate-schemas)
 
 (deftest make-message-test
   (testing "it makes a message"

--- a/test/puppetlabs/pcp/message_test.clj
+++ b/test/puppetlabs/pcp/message_test.clj
@@ -75,10 +75,11 @@
 
 (deftest encode-test
   (testing "when being strict, we take a Message only"
-    (s/with-fn-validation
-      (is (thrown+? [:type :schema.core/error]
-                    (encode {}))
-          "Rejected an empty map as a Message")))
+    (is (thrown+? [:type :schema.core/error]
+                  (encode {}))
+        "Rejected an empty map as a Message"))
+  ;; don't include the envelope in the encoded messages in the following
+  ;; tests for the sake of brevity
   (with-redefs [message->envelope (constantly {})]
     (testing "it returns a byte array"
       ;; subsequent tests will use vec to ignore this
@@ -102,43 +103,46 @@
              (vec (encode (set-data (make-message) (string->bytes "haha")))))))))
 
 (deftest decode-test
-  (with-redefs [schema.core/validate (fn [s d] d)]
-    (testing "it only handles version 1 messages"
-      (is (thrown+? [:type :puppetlabs.pcp.message/message-malformed]
-                    (decode (byte-array [2])))))
-    (testing "it insists on envelope chunk first"
-      (is (thrown+? [:type :puppetlabs.pcp.message/message-invalid]
-                    (decode (byte-array [1,
-                                         2, 0 0 0 2, 123 125])))))
-    (testing "it decodes the null message"
-      (is (= (dissoc (message->envelope (make-message)) :id)
-             (dissoc (message->envelope (decode (byte-array [1, 1, 0 0 0 2, 123 125]))) :id))))
-    (testing "it insists on a well-formed envelope"
-      (is (thrown+? [:type :puppetlabs.pcp.message/envelope-malformed]
-                    (decode (byte-array [1,
-                                         1, 0 0 0 1, 123])))))
-    (testing "it insists on a complete envelope"
-      (with-redefs [schema.core/validate (fn [s d] (throw (Exception. "oh dear")))]
-        (is (thrown+? [:type :puppetlabs.pcp.message/envelope-invalid]
-                      (decode (byte-array [1,
-                                           1, 0 0 0 2, 123 125]))))))
-    (testing "data is accessible"
-      (let [message (decode (byte-array [1,
-                                         1, 0 0 0 2, 123 125,
-                                         2, 0 0 0 3, 108 111 108]))]
-        (is (= (String. (get-data message)) "lol"))))
-    (testing "debug is accessible"
-      (let [message (decode (byte-array [1,
-                                         1, 0 0 0 2, 123 125,
-                                         2, 0 0 0 0,
-                                         3, 0 0 0 3, 108 111 108]))]
-        (is (= "lol" (String. (get-debug message))))))))
+  (testing "it only handles version 1 messages"
+    (is (thrown+? [:type :puppetlabs.pcp.message/message-malformed]
+                  (decode (byte-array [2])))))
+  (testing "it insists on envelope chunk first"
+    (is (thrown+? [:type :puppetlabs.pcp.message/message-invalid]
+                  (decode (byte-array [1,
+                                       2, 0 0 0 2, 123 125])))))
+  (testing "it insists on a well-formed envelope"
+    (is (thrown+? [:type :puppetlabs.pcp.message/envelope-malformed]
+                  (decode (byte-array [1,
+                                       1, 0 0 0 1, 123])))))
+  (testing "it insists on a complete envelope"
+    (is (thrown+? [:type :puppetlabs.pcp.message/envelope-invalid]
+                  (decode (byte-array [1,
+                                       1, 0 0 0 2, 123 125])))))
+  ;; disable schema validations (both signature validations and explicit
+  ;; calls to `schema.core/validate`) for the following tests as the byte
+  ;; arrays used in them don't match the expected schemas for the sake
+  ;; of brevity
+  (s/without-fn-validation
+    (with-redefs [schema.core/validate (fn [_ v] v)]
+      (testing "it decodes the null message"
+        (is (= (dissoc (message->envelope (make-message)) :id)
+               (dissoc (message->envelope (decode (byte-array [1, 1, 0 0 0 2, 123 125]))) :id))))
+      (testing "data is accessible"
+        (let [message (decode (byte-array [1,
+                                           1, 0 0 0 2, 123 125,
+                                           2, 0 0 0 3, 108 111 108]))]
+          (is (= "lol" (String. (get-data message))))))
+      (testing "debug is accessible"
+        (let [message (decode (byte-array [1,
+                                           1, 0 0 0 2, 123 125,
+                                           2, 0 0 0 0,
+                                           3, 0 0 0 3, 108 111 108]))]
+          (is (= "lol" (String. (get-debug message)))))))))
 
 (deftest encoder-roundtrip-test
-  (with-redefs [schema.core/validate (fn [s d] d)]
-    (testing "it can roundtrip data"
-      (let [data (byte-array (map byte "hola"))
-            encoded (encode (set-data (make-message) data))
-            decoded (decode encoded)]
-        (is (= (vec (get-data decoded))
-               (vec data)))))))
+  (testing "it can roundtrip data"
+    (let [data (byte-array (map byte "hola"))
+          encoded (encode (set-data (make-message :sender "pcp://client01.example.com/test") data))
+          decoded (decode encoded)]
+      (is (= (vec (get-data decoded))
+             (vec data))))))

--- a/test/puppetlabs/pcp/protocol_test.clj
+++ b/test/puppetlabs/pcp/protocol_test.clj
@@ -2,7 +2,10 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.pcp.protocol :refer :all]
             [puppetlabs.kitchensink.core :as ks]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [schema.test :as st]))
+
+(use-fixtures :once st/validate-schemas)
 
 (deftest uri-schema-test
   (testing "valid uris"


### PR DESCRIPTION
In this PR we disable the schema validations by default by removing the `^:always-validate` attribute from all functions in this projects which used it.
To compensate for that the tests in this project now use the `schema.test/validate-schemas` fixture so that they still run with the validations enabled. In addition to that since the use of the fixture enables the validations globally i.e. even for code for which they were not enabled previously for which some of the tests were not prepared, those tests needed to be updated.