### PR TITLE
(PCP-483) Fix InventoryRequest schema

### DIFF
--- a/src/puppetlabs/pcp/protocol.clj
+++ b/src/puppetlabs/pcp/protocol.clj
@@ -8,7 +8,7 @@
   (s/pred ks/datetime? 'datetime?))
 
 (def Uri
-  "Schema for Cthun node Uri"
+  "Schema for PCP node Uri"
   (s/pred (partial re-matches #"^pcp://[^/]*/[^/]+$") 'uri?))
 
 (defn uuid?
@@ -37,7 +37,7 @@
 
 (def InventoryRequest
   "Data schema for http://puppetlabs.com/inventory_request"
-  {:query [s/Str]})
+  {:query [Uri]})
 
 (def InventoryResponse
   "Data schema for http://puppetlabs.com/inventory_response"


### PR DESCRIPTION
According to
https://github.com/puppetlabs/pcp-specifications/blob/master/pcp/versions/1.0/inventory.md,
the InventoryRequest expects query to be an array of strings matching
the PCP URI pattern. However,
https://github.com/puppetlabs/clj-pcp-common/blob/0.5.0/src/puppetlabs/pcp/protocol.clj#L38-L40
only expects the schema to match any string.

Currently clj-pxp-puppet is the only Clojure client using
inventory_request, and hard-codes the query. However, in PCP-474 the
intent is to change that query to be user-facing. With that change,
clj-pxp-puppet is not correctly validating the InventoryRequest, which
results in a schema failure in the pcp-broker. Fix the schema for
InventoryRequest.