### PR TITLE
(maint) Update dependencies to play well with upstream projects

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,10 +14,10 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.logging "0.3.1"]
 
-                 [puppetlabs/kitchensink "1.1.0"]
+                 [puppetlabs/kitchensink "1.3.0"]
 
                  [cheshire "5.5.0"]
-                 [prismatic/schema "0.4.3"]
+                 [prismatic/schema "1.0.4"]
 
                  [clj-time "0.9.0"]
 


### PR DESCRIPTION
Upstream projects use newer versions of trapperkeeper that depend on
newer versions of schema and kitchensink. Update the dependencies to be
consistent with those upstream projects.