### PR TITLE
(PCP-600) Inventory updates prerequisites

### DIFF
--- a/test/puppetlabs/pcp/protocol_test.clj
+++ b/test/puppetlabs/pcp/protocol_test.clj
@@ -29,6 +29,7 @@
     (is (= ["*" "agent"] (explode-uri "pcp://*/agent")))))
 
 (deftest uri-wildcard?-test
-  (is (= true  (uri-wildcard? "pcp://*/agent")))
-  (is (= true  (uri-wildcard? "pcp://agent01.example.com/*")))
-  (is (= false (uri-wildcard? "pcp://agent01.example.com/agent"))))
+  (is (= ["*" "*"]  (uri-wildcard? "pcp://*/*")))
+  (is (= ["*" "agent"]  (uri-wildcard? "pcp://*/agent")))
+  (is (= ["agent01.example.com" "*"] (uri-wildcard? "pcp://agent01.example.com/*")))
+  (is (= nil (uri-wildcard? "pcp://agent01.example.com/agent"))))


### PR DESCRIPTION
This commit adds schema definitions to be used in inventory updates.
Additionally it changes the return value of the `(uri-wildcard? )` function to be the exploded Uri in case it is a wildcard Uri or nil otherwise.
This should not cause problems as the truthiness of the newly returned values is the same is that of originally returned bool values in clojure.