### PR TITLE
(maint) split error_message schema by version

### DIFF
--- a/src/puppetlabs/pcp/protocol.clj
+++ b/src/puppetlabs/pcp/protocol.clj
@@ -75,6 +75,10 @@
   {(s/optional-key :id) MessageId
    :description s/Str})
 
+(def v2-ErrorMessage
+  "Data schema for http://puppetlabs.com/error_message"
+  s/Str)
+
 (def TTLExpiredMessage
   "Data schema for http://puppetlabs.com/ttl_expired"
   {:id MessageId})


### PR DESCRIPTION
Change the existing error_message schema to v1-ErrorMessage and add a
v2-ErrorMessage to conform to the v2 PCP spec.