### PR TITLE
(maint) remove uuid?, update clj-parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.0
+
+This is a maintenance release.
+
+* update clj-parent to 3.1.1
+* remove implementation of uuid?  If an alternative is needed, use kitchensink.core/uuid?
+
 ## 1.2.0
 
 This is a feature release.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/pcp-common "1.2.1-SNAPSHOT"
+(defproject puppetlabs/pcp-common "1.3.0-SNAPSHOT"
   :description "Common protocol components for PCP"
   :url "https://github.com/puppetlabs/clj-pcp-common"
   :license {:name "Apache License, Version 2.0"
@@ -11,7 +11,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "2.0.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "3.1.1"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/src/puppetlabs/pcp/protocol.clj
+++ b/src/puppetlabs/pcp/protocol.clj
@@ -19,13 +19,9 @@
   "Schema for a single change in inventory record"
   {:client Uri :change (s/enum -1 1)})
 
-(defn uuid?
-  [uuid]
-  (re-matches #"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$" uuid))
-
 (def MessageId
-  "A message identifier"
-  (s/pred uuid?))
+  "A message identifier, as a string"
+  (s/pred ks/uuid?))
 
 (def v2-Envelope
   "Defines the envelope format of a v2 message"

--- a/test/puppetlabs/pcp/protocol_test.clj
+++ b/test/puppetlabs/pcp/protocol_test.clj
@@ -16,10 +16,6 @@
     (is (thrown? Exception (s/validate Uri "server")))
     (is (thrown? Exception (s/validate Uri "pcp://test/with/too_many_slashes")))))
 
-(deftest uuid?-test
-  (is (uuid? (ks/uuid)))
-  (is (not (uuid? "let me tell you a story"))))
-
 (deftest explode-uri-test
   (testing "It raises on invalid uris"
     (is (thrown? Exception (explode-uri ""))))


### PR DESCRIPTION
This removes uuid? which is now part of clojure and causes a warning
every time the code is loaded.

This also updates clj-parent to 3.1.1.