### PR TITLE
(maint) update clj-parent to 4.2.10, remove nippy dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: clojure
 sudo: false
 lein: 2.8.1
 jdk:
-  - oraclejdk9
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 script:
   - lein test
   - lein with-profile test-schema-validation test

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "3.1.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.2.10"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -19,7 +19,6 @@
                  [puppetlabs/kitchensink]
                  [cheshire]
                  [prismatic/schema]
-                 [com.taoensso/nippy]
 
                  [org.clojars.smee/binary "0.3.0"]
 


### PR DESCRIPTION
The "nippy" dependency isn't being used in this library and causes
inclusion in downstream consumers.  This removes it as well as updates
to clj-parent 4.2.10