### PR TITLE
(PE-31800) update clj-parent to 4.6.20

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.6.17"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.6.20"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This commit updates clj-parent to 4.6.20 to update Jetty
to 9.4.40. This resolves a number of CVEs and issues in Jetty.